### PR TITLE
chore(ci): update workflow actions and drop legacy GitHub Packages auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/gregg-deploy-azure.yml
+++ b/.github/workflows/gregg-deploy-azure.yml
@@ -22,21 +22,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
-
-      - name: .npmrc registry login
-        uses: healthplace/npmrc-registry-login-action@v1.0.9
-        with:
-          scope: "@orgbookclub"
-          registry: https://npm.pkg.github.com
-          # The registry auth token
-          auth-token: ${{ secrets.OWS_PACKAGE_READER_PAT }}
 
       - name: yarn install and build
         run: |
@@ -45,7 +37,7 @@ jobs:
 
       - name: "Deploy to Azure Web App"
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}

--- a/.github/workflows/gregg-develop-ci.yml
+++ b/.github/workflows/gregg-develop-ci.yml
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
 
     strategy:
       matrix:
@@ -22,18 +21,16 @@ jobs:
 
     steps:
       - name: Checkout Source Files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
-          registry-url: "https://npm.pkg.github.com"
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Source Files
         run: yarn lint

--- a/.github/workflows/gregg-prod-deploy-azure.yml
+++ b/.github/workflows/gregg-prod-deploy-azure.yml
@@ -22,21 +22,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "yarn"
-
-      - name: .npmrc registry login
-        uses: healthplace/npmrc-registry-login-action@v1.0.9
-        with:
-          scope: "@orgbookclub"
-          registry: https://npm.pkg.github.com
-          # The registry auth token
-          auth-token: ${{ secrets.OWS_PACKAGE_READER_PAT }}
 
       - name: yarn install and build
         run: |
@@ -45,7 +37,7 @@ jobs:
 
       - name: "Deploy to Azure WebApp"
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_GREGG_PUBLISH_PROFILE }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-@orgbookclub:registry=https://npm.pkg.github.com
 engine-strict=true


### PR DESCRIPTION
## Summary

Cleans up the GitHub Actions workflows: bumps deprecated action versions and removes the legacy GitHub Packages auth that's no longer needed now that `@organizedbookclub/ows-client` is published on public npm.

No workflow files were unused — CI, dev deploy, and prod deploy were all kept.

## Changes

**Action version bumps** (the v3 versions of checkout/setup-node are deprecated and run on Node 16):
- `actions/checkout@v3` → `@v4` in all three workflows
- `actions/setup-node@v3` → `@v4` in all three workflows
- `azure/webapps-deploy@v2` → `@v3` in both deploy workflows

**Develop CI (`gregg-develop-ci.yml`)**
- Added `cache: "yarn"` to setup-node
- Use `${{ matrix.node-version }}` instead of a hard-coded `"20.x"`
- Removed `registry-url: https://npm.pkg.github.com`, `NODE_AUTH_TOKEN`, and the `packages: read` permission — no longer needed

**Deploy workflows (dev + prod)**
- Removed the `healthplace/npmrc-registry-login-action` step that authenticated to GitHub Packages for the legacy `@orgbookclub` scope (no such dependency exists anymore)

**Other**
- `.npmrc`: dropped the dead `@orgbookclub:registry=https://npm.pkg.github.com` line; kept `engine-strict=true`
- `.github/dependabot.yml`: added the `github-actions` ecosystem so action versions stay current automatically going forward

## Verification

Locally:
- `yarn install --frozen-lockfile` ✅ (resolves `@organizedbookclub/ows-client` from public npm without any token)
- `yarn lint` ✅
- `yarn build` ✅

## Follow-up

The repo secret `OWS_PACKAGE_READER_PAT` and any token tied to the legacy `@orgbookclub` GitHub Packages scope are no longer referenced by any workflow and can be revoked / removed when convenient.