### PR TITLE
chore(node): upgrade runtime to Node 24

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Gregg is a TypeScript Discord bot (discord.js v14) for the Organized Book Club s
 
 ## Build, lint, run
 
-- Install: `yarn install --frozen-lockfile` (Node 20.x). `@organizedbookclub/ows-client` is published on public npm (`registry.npmjs.org`); no auth needed. (Older CI workflows still log in to GitHub Packages for the legacy `@orgbookclub` scope — those steps are now no-ops and can be removed in a cleanup pass.) `postinstall` runs `prisma generate` against `prisma/schema.prisma`.
+- Install: `yarn install --frozen-lockfile` (Node 24.x). `@organizedbookclub/ows-client` is published on public npm (`registry.npmjs.org`); no auth needed. (Older CI workflows still log in to GitHub Packages for the legacy `@orgbookclub` scope — those steps are now no-ops and can be removed in a cleanup pass.) `postinstall` runs `prisma generate` against `prisma/schema.prisma`.
 - Build: `yarn build` (`tsc` → `./dist`). `yarn prebuild` cleans `./dist`.
 - Lint: `yarn lint` (ESLint with `--max-warnings 0`, then Prettier `--check`). Auto-fix: `yarn lint:fix`. CI runs `yarn lint` then `yarn build`; both must pass.
 - Run dev: `yarn start:dev` (rebuilds, then `node -r dotenv/config ./dist/index.js`). Run prod: `yarn start`. Required env vars are listed in `sample.env` and validated in `src/validateEnv.ts` (the process exits if any are missing).

--- a/.github/workflows/gregg-deploy-azure.yml
+++ b/.github/workflows/gregg-deploy-azure.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   AZURE_WEBAPP_NAME: gregg-dev # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: "." # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: "20.x"
+  NODE_VERSION: "24.x"
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/gregg-develop-ci.yml
+++ b/.github/workflows/gregg-develop-ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout Source Files

--- a/.github/workflows/gregg-prod-deploy-azure.yml
+++ b/.github/workflows/gregg-prod-deploy-azure.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   AZURE_WEBAPP_NAME: gregg-bot # set this to your application's name
   AZURE_WEBAPP_PACKAGE_PATH: "." # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: "20.x"
+  NODE_VERSION: "24.x"
 
 jobs:
   build-and-deploy:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/orgbookclub/gregg/issues"
   },
   "homepage": "https://gregg-bot.azurewebsites.net/",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "prebuild": "rimraf ./dist",
     "build": "tsc",
@@ -44,7 +47,7 @@
     "@eslint/eslintrc": "^3.3.0",
     "@eslint/js": "^9.39.2",
     "@types/express": "^4.17.17",
-    "@types/node": "^22.15.21",
+    "@types/node": "^24.12.4",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.24.1",
     "csv": "^6.3.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2023",
     "module": "CommonJS",
     "rootDir": "./src",
     "outDir": "./dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,12 +836,19 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^22.15.21":
+"@types/node@*":
   version "22.15.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.21.tgz#196ef14fe20d87f7caf1e7b39832767f9a995b77"
   integrity sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/node@^24.12.4":
+  version "24.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
+  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/pg-pool@2.0.7":
   version "2.0.7"
@@ -3687,6 +3694,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@6.24.1:
   version "6.24.1"


### PR DESCRIPTION
## Summary

Aligns the codebase, CI, deploy workflows, and the dev Azure webapp with Node 24. The prod webapp (`gregg-bot`) was already running `NODE|24-lts`; this PR brings everything else up to match so the runtime is consistent end-to-end and the CI build actually exercises the version we deploy on.

No source-code changes were needed — the bot is Node-24 compatible as-is.

## Changes

**CI / deploy workflows**
- `.github/workflows/gregg-develop-ci.yml`: matrix `node-version` `20.x` → `24.x`
- `.github/workflows/gregg-deploy-azure.yml` (dev deploy): `NODE_VERSION` `20.x` → `24.x`
- `.github/workflows/gregg-prod-deploy-azure.yml` (prod deploy): `NODE_VERSION` `20.x` → `24.x`

**Package metadata**
- `package.json`: added `engines.node: ">=24.0.0"` so anyone installing on an older runtime gets a clear warning
- `package.json` / `yarn.lock`: bumped `@types/node` `^22.15.21` → `^24.12.4`

**TypeScript config**
- `tsconfig.json`: `target` `ES6` → `ES2023`. Required after the `@types/node` bump — the v24 types stop shipping the looser implicit lib that previously let `Array.prototype.at` (used in `src/utils/loadCommands.ts` and `src/utils/loadEventListeners.ts`) compile under an ES6 target. Node 24 supports ES2023 natively, so this is a no-op at runtime.

**Docs**
- `.github/copilot-instructions.md`: install step now says "Node 24.x" instead of "Node 20.x".

**Azure (out-of-band, applied via `az` CLI — not in the diff)**
- `gregg-dev` `linuxFxVersion`: `NODE|22-lts` → `NODE|24-lts`
- `gregg-bot`: already on `NODE|24-lts`, no change

## Verification

Locally on Node 24.13.0:
- ✅ `yarn install` (lockfile updated cleanly)
- ✅ `yarn lint` (`--max-warnings 0` + Prettier)
- ✅ `yarn build`
- ✅ `node ./dist/index.js` boots through env validation, command loading, slash-command registration with the home guild, DB init, sprint manager init, and event-listener attachment. The only error surfaced is the expected `ECONNREFUSED` to the local OWS API — no Node-24-related runtime/syntax issues.

There is no automated test suite in this repo; lint + build is the full CI gate.

## Out of scope

- Bumping any runtime dependency for the sake of it — only `@types/node` moved, because dropping the type bump leaves CI on stale types vs. the deploy target.
- Source-level use of any Node 24 / ES2023 features. The `target` bump enables them but nothing in this PR adopts them.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
