### PR TITLE
feat(reader-roles): award window roles to top scorers

### DIFF
--- a/src/jobs/updateReaderRoles.ts
+++ b/src/jobs/updateReaderRoles.ts
@@ -16,6 +16,7 @@ import { titles } from "../config/constants";
 import { Bot, Job } from "../models";
 import {
   DateWindow,
+  isAllTimeWindow,
   toEventEndDateFilter,
   windowFromPreset,
 } from "../utils/dateWindow";
@@ -137,7 +138,7 @@ async function processReaderRole(
   // recognition tier — "Reader of the Month/Year" — awarded to the member(s)
   // with the highest score in the window, provided they also clear the
   // configured points floor. Ties result in all tied members holding the role.
-  const isTopScorerMode = readerRole.window !== "all-time";
+  const isTopScorerMode = !isAllTimeWindow(window);
   let winners: Set<string> | undefined;
   if (isTopScorerMode) {
     let maxPoints = -1;

--- a/src/jobs/updateReaderRoles.ts
+++ b/src/jobs/updateReaderRoles.ts
@@ -133,17 +133,77 @@ async function processReaderRole(
     if (hasRole(member, role.id)) candidateIds.add(member.id);
   }
 
+  // For non-all-time windows (e.g. "this-year", "this-month") the role is a
+  // recognition tier — "Reader of the Month/Year" — awarded to the member(s)
+  // with the highest score in the window, provided they also clear the
+  // configured points floor. Ties result in all tied members holding the role.
+  const isTopScorerMode = readerRole.window !== "all-time";
+  let winners: Set<string> | undefined;
+  if (isTopScorerMode) {
+    let maxPoints = -1;
+    for (const discordId of candidateIds) {
+      if (!guildMembers.has(discordId)) continue;
+      const points = scoreMap.get(discordId) ?? 0;
+      if (points >= readerRole.points && points > maxPoints) {
+        maxPoints = points;
+      }
+    }
+    winners = new Set<string>();
+    if (maxPoints >= readerRole.points && maxPoints > 0) {
+      for (const discordId of candidateIds) {
+        if (!guildMembers.has(discordId)) continue;
+        const points = scoreMap.get(discordId) ?? 0;
+        if (points === maxPoints) winners.add(discordId);
+      }
+    }
+  }
+
   for (const discordId of candidateIds) {
     const member = guildMembers.get(discordId);
     if (!member) continue;
     const points = scoreMap.get(discordId) ?? 0;
-    await updateMemberRole(
-      role,
-      readerRole.points,
-      member,
-      points,
-      logWebhookUrl,
+    if (isTopScorerMode && winners) {
+      await updateMemberRoleTopScorer(
+        role,
+        member,
+        winners.has(discordId),
+        logWebhookUrl,
+      );
+    } else {
+      await updateMemberRole(
+        role,
+        readerRole.points,
+        member,
+        points,
+        logWebhookUrl,
+      );
+    }
+  }
+}
+
+async function updateMemberRoleTopScorer(
+  role: Role,
+  member: GuildMember,
+  shouldHold: boolean,
+  logWebhookUrl: string,
+) {
+  const embed = new EmbedBuilder()
+    .setColor(Colors.Gold)
+    .setTitle(titles.ReaderRoleUpdate)
+    .setTimestamp();
+
+  if (hasRole(member, role.id) && !shouldHold) {
+    await member.roles.remove(role);
+    embed.setDescription(
+      `${roleMention(role.id)} removed from ${userMention(member.id)}`,
     );
+    await logToWebhook({ embeds: [embed] }, logWebhookUrl);
+  } else if (!hasRole(member, role.id) && shouldHold) {
+    await member.roles.add(role);
+    embed.setDescription(
+      `${roleMention(role.id)} added to ${userMention(member.id)}`,
+    );
+    await logToWebhook({ embeds: [embed] }, logWebhookUrl);
   }
 }
 


### PR DESCRIPTION
## Why

Reader roles configured for monthly or yearly windows are recognition tiers (for example, Reader of the Month/Year), so they should identify the top scorer or tied top scorers in that window rather than every member above the points threshold.

## What changed

- Keeps `all-time` reader roles on the existing points-threshold behavior.
- Treats non-`all-time` reader roles as top-scorer awards gated by the configured points floor.
- Preserves tied winners by allowing every member with the max qualifying score to hold the role.
- Adds separate add/remove handling for top-scorer mode so current holders are removed when they are no longer winners.

## Out of scope

- No persistence changes for reader-role state.
- No changes to readerboard scoring or event-window calculation.
- A zero-point top score intentionally produces no winner, even if the configured floor is `0`.

## Validation

- `yarn lint`
- `yarn build`

## Breaking changes

Non-`all-time` reader roles now behave as top-scorer awards instead of threshold roles, so members above the threshold but below the window's top score will lose that role.
